### PR TITLE
Added rel="stylesheet" in index.html docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@ slug: home
         section of your HTML.
 
 <pre class="code">
-&lt;link href="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0-beta.3/css/select2.min.css" /&gt;
+&lt;link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0-beta.3/css/select2.min.css" /&gt;
 &lt;script src="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0-beta.3/js/select2.min.js"&gt;&lt;/script&gt;
 </pre>
 
@@ -118,7 +118,7 @@ slug: home
         section of your HTML.
 
 <pre class="code">
-&lt;link href="path/to/select2.min.css" /&gt;
+&lt;link rel="stylesheet" href="path/to/select2.min.css" /&gt;
 &lt;script src="path/to/select2.min.js"&gt;&lt;/script&gt;
 </pre>
       </li>


### PR DESCRIPTION
`rel="stylesheet"` attribute was missing on the `<link>` tags in the documentation.
